### PR TITLE
Default hostname to `DATADOG_TRACE_AGENT_HOSTNAME` if available

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from os import getpid
+from os import environ, getpid
 
 from .ext import system
 from .provider import DefaultContextProvider
@@ -27,7 +27,7 @@ class Tracer(object):
         from ddtrace import tracer
         trace = tracer.trace("app.request", "web-server").finish()
     """
-    DEFAULT_HOSTNAME = 'localhost'
+    DEFAULT_HOSTNAME = environ.get('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost')
     DEFAULT_PORT = 8126
 
     def __init__(self):

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -4,7 +4,9 @@ tests for Tracer and utilities.
 
 import time
 from os import getpid
+import sys
 
+import mock
 from nose.tools import assert_raises, eq_, ok_
 from unittest.case import SkipTest
 
@@ -517,3 +519,16 @@ def get_dummy_tracer():
     tracer = Tracer()
     tracer.writer = DummyWriter()
     return tracer
+
+
+def test_default_hostname_from_env():
+    # it should use default hostname from DATADOG_TRACE_AGENT_HOSTNAME if available
+    try:
+        with mock.patch.dict('os.environ', {'DATADOG_TRACE_AGENT_HOSTNAME': 'customhost'}):
+            del sys.modules['ddtrace.tracer']  # force reload of module
+            from ddtrace.tracer import Tracer
+            eq_('customhost', Tracer.DEFAULT_HOSTNAME)
+    finally:
+        del sys.modules['ddtrace.tracer']  # clean up our test module
+        from ddtrace.tracer import Tracer
+        eq_('localhost', Tracer.DEFAULT_HOSTNAME)


### PR DESCRIPTION
We'll merge this into the carium branch in our fork and merge that into DD's.